### PR TITLE
feat: prepare repository for open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve the workshop
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+
+- IDE: [e.g. VS Code, IntelliJ]
+- GitHub Copilot version: [e.g. 1.0.0]
+- Exercise: [e.g. completions-exercise.md]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this workshop
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Type of contribution:**
+
+- [ ] New exercise
+- [ ] New prompting technique
+- [ ] Documentation improvement
+- [ ] Language-specific example
+- [ ] Other (please specify)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] New exercise or workshop content
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes.
+
+- [ ] I have tested the workshop content myself
+- [ ] I have verified all code examples work
+- [ ] I have checked external links are functional
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own changes
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to GitHub Copilot Workshop
+
+Thank you for your interest in contributing to this workshop! This guide will help you get started.
+
+## 🤝 How to Contribute
+
+### Types of Contributions We Welcome
+
+- **New exercises**: Additional hands-on activities for different skill levels
+- **Improved documentation**: Clarifications, corrections, or additional examples
+- **New prompting techniques**: Effective patterns you've discovered
+- **Language-specific examples**: Examples for different programming languages
+- **Bug fixes**: Corrections to existing content or broken links
+- **Feature requests**: Ideas for new workshop content
+
+### Getting Started
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork** locally:
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/copilot-workshop.git
+   cd copilot-workshop
+   ```
+3. **Install dependencies**:
+   ```bash
+   npm install
+   ```
+4. **Create a branch** for your contribution:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+### Making Changes
+
+#### For Documentation Changes
+
+- Follow the existing Markdown formatting style
+- Use consistent heading structure
+- Test all code examples
+- Run `npm run format:md` to ensure consistent formatting
+
+#### For New Exercises
+
+- Use the template in `.templates/workshop-exercise.template.md`
+- Include clear learning objectives
+- Provide step-by-step instructions
+- Add challenge activities for practice
+- Test the exercise yourself
+
+#### For New Prompting Examples
+
+- Add them to `resources/effective-prompts.md`
+- Include both effective and less effective examples
+- Explain why the prompts work well
+- Consider different experience levels
+
+### Code Style & Standards
+
+- Use Prettier for Markdown formatting (`npm run format:md`)
+- Follow the existing file naming conventions
+- Keep line lengths reasonable (around 100 characters)
+- Use semantic line breaks in Markdown
+- Include proper attribution for external sources
+
+### Submitting Your Contribution
+
+1. **Test your changes** thoroughly
+2. **Commit your changes** with clear, descriptive messages:
+   ```bash
+   git commit -m "Add exercise for debugging with Copilot Chat"
+   ```
+3. **Push to your fork**:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+4. **Create a Pull Request** on GitHub with:
+   - Clear title describing the change
+   - Detailed description of what you've added/changed
+   - Context about why the change is beneficial
+   - Screenshots if applicable
+
+### Pull Request Guidelines
+
+- Link any related issues
+- Ensure all existing exercises still work
+- Update the table of contents if you've added new content
+- Consider if documentation needs updates
+- Be responsive to feedback and requests for changes
+
+## 🎯 Content Guidelines
+
+### Educational Quality
+
+- Content should be beginner-friendly but also valuable for experienced developers
+- Include both theory and practical examples
+- Provide context for why techniques are useful
+- Consider different learning styles
+
+### Inclusivity
+
+- Use inclusive language
+- Avoid assumptions about prior knowledge
+- Provide multiple approaches when possible
+- Consider accessibility in examples
+
+### Technical Accuracy
+
+- Test all code examples
+- Verify external links work
+- Ensure compatibility with current Copilot features
+- Update outdated information
+
+## 📝 Reporting Issues
+
+If you find bugs, have suggestions, or need clarification:
+
+1. **Check existing issues** first to avoid duplicates
+2. **Use the appropriate issue template**
+3. **Provide clear reproduction steps** for bugs
+4. **Include environment details** (IDE, Copilot version, etc.)
+
+## 💡 Getting Help
+
+- **GitHub Discussions**: For questions about using the workshop content
+- **Issues**: For bugs or specific improvement suggestions
+- **Email**: Reach out to the maintainers for complex discussions
+
+## 🙏 Recognition
+
+All contributors will be recognized in the repository. We appreciate every contribution, whether it's fixing a typo or adding a major new feature!
+
+## 📜 License
+
+By contributing to this project, you agree that your contributions will be licensed under the same MIT License that covers the project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Michael Schilling & Cas van Dinter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+This workshop content is continuously updated. We recommend using the latest version from the main branch.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this workshop content, please report it by:
+
+1. **Email**: Send details to the repository maintainers
+2. **GitHub Security**: Use GitHub's private vulnerability reporting feature
+3. **Issues**: For non-sensitive issues, create a public issue
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if known)
+
+## Workshop Security Considerations
+
+This workshop is educational content about GitHub Copilot. However, when working with the exercises:
+
+- **Never commit real API keys or secrets** to any repository
+- **Use dummy data** in examples
+- **Be cautious with generated code** - always review before using in production
+- **Follow your organization's security policies** when using Copilot
+
+## Response Timeline
+
+- We aim to respond to security reports within 48 hours
+- Critical vulnerabilities will be addressed as soon as possible
+- Non-critical issues will be included in the next regular update
+
+Thank you for helping keep this workshop secure and valuable for everyone!

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "copilot-workshop",
   "version": "1.0.0",
   "description": "Workshop materials for learning GitHub Copilot features and best practices",
-  "private": true,
   "scripts": {
     "format:md": "prettier --write \"**/*.md\"",
     "format:check": "prettier --check \"**/*.md\""

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "copilot-workshop",
   "version": "1.0.0",
   "description": "Workshop materials for learning GitHub Copilot features and best practices",
+  "main": "README.md",
   "scripts": {
     "format:md": "prettier --write \"**/*.md\"",
     "format:check": "prettier --check \"**/*.md\""
@@ -15,15 +16,23 @@
     "copilot",
     "workshop",
     "ai",
-    "code-assistant"
+    "code-assistant",
+    "programming",
+    "education",
+    "tutorial",
+    "artificial-intelligence",
+    "developer-tools"
   ],
   "author": "Michael Schilling & Cas van Dinter",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/move4mobile/copilot-workshop/issues"
   },
   "homepage": "https://github.com/move4mobile/copilot-workshop#readme",
   "devDependencies": {
     "prettier": "^3.5.3"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
This pull request prepares the repository for open source by updating key metadata and adding documentation for contributions and security.

- Update package.json by replacing the "private" flag with a "main" property, revising keywords, updating the license, and adding engine requirements.
- Add a new SECURITY.md file to outline security policies.
- Introduce a LICENSE file with the MIT License and new contribution and issue templates to guide community contributions.
- 